### PR TITLE
Fixed mint token call and updated Navbar

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,23 +1,25 @@
-import { Adb } from "@mui/icons-material";
+
 import MenuIcon from "@mui/icons-material/Menu";
+import { EthuiIconWhite } from "./icons/EthuiIconWhite";
 import {
   AppBar,
   Box,
   Container,
-  IconButton,
   Toolbar,
   Typography,
 } from "@mui/material";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
 
-const title = "Iron Demo";
+const title = "ethui Demo";
 
 export function Navbar() {
   return (
     <AppBar position="static">
       <Container maxWidth="xl">
         <Toolbar disableGutters>
-          <Adb sx={{ display: { xs: "none", md: "flex" }, mr: 1 }} />
+          <Box sx={{ display: { xs: "none", md: "flex" }, mr: 1 }}>
+            <EthuiIconWhite />
+          </Box>
           <Typography
             variant="h6"
             noWrap
@@ -38,10 +40,11 @@ export function Navbar() {
 
           <Box sx={{ flexGrow: 1, display: { xs: "flex", md: "none" } }}>
             <MenuIcon />
-
             <span />
           </Box>
-          <Adb sx={{ display: { xs: "flex", md: "none" }, mr: 1 }} />
+          <Box sx={{ display: { xs: "flex", md: "none" }, mr: 1 }}>
+            <EthuiIconWhite />
+          </Box>
           <Typography
             variant="h5"
             noWrap

--- a/src/components/icons/EthuiIconWhite.tsx
+++ b/src/components/icons/EthuiIconWhite.tsx
@@ -1,14 +1,33 @@
-import * as React from 'react';
-import SvgIcon from '@mui/material/SvgIcon';
+import * as React from "react";
+import SvgIcon from "@mui/material/SvgIcon";
 
 export function EthuiIconWhite() {
   return (
     <SvgIcon>
-<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 130.97C0 58.6375 58.6374 0 130.97 0L469.03 0C541.363 0 600 58.6374 600 130.97L600 469.027C600 541.36 541.363 599.997 469.03 599.997L130.97 599.997C58.6374 599.997 0 541.36 0 469.027L0 130.97Z" fill="#F1F1F1"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M492.006 372L300.006 114L108.006 372H217.24L300.006 260.783L382.772 372H492.006Z" fill="#161616"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M216.006 372L300.006 486L384.006 372L336.216 372L300.006 421.142L263.796 372L216.006 372Z" fill="#161616"/>
-</svg>
+      <svg
+        width="600"
+        height="600"
+        viewBox="0 0 600 600"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0 130.97C0 58.6375 58.6374 0 130.97 0L469.03 0C541.363 0 600 58.6374 600 130.97L600 469.027C600 541.36 541.363 599.997 469.03 599.997L130.97 599.997C58.6374 599.997 0 541.36 0 469.027L0 130.97Z"
+          fill="#F1F1F1"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M492.006 372L300.006 114L108.006 372H217.24L300.006 260.783L382.772 372H492.006Z"
+          fill="#161616"
+        />
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M216.006 372L300.006 486L384.006 372L336.216 372L300.006 421.142L263.796 372L216.006 372Z"
+          fill="#161616"
+        />
+      </svg>
     </SvgIcon>
   );
 }

--- a/src/components/icons/EthuiIconWhite.tsx
+++ b/src/components/icons/EthuiIconWhite.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import SvgIcon from '@mui/material/SvgIcon';
+
+export function EthuiIconWhite() {
+  return (
+    <SvgIcon>
+<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 130.97C0 58.6375 58.6374 0 130.97 0L469.03 0C541.363 0 600 58.6374 600 130.97L600 469.027C600 541.36 541.363 599.997 469.03 599.997L130.97 599.997C58.6374 599.997 0 541.36 0 469.027L0 130.97Z" fill="#F1F1F1"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M492.006 372L300.006 114L108.006 372H217.24L300.006 260.783L382.772 372H492.006Z" fill="#161616"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M216.006 372L300.006 486L384.006 372L336.216 372L300.006 421.142L263.796 372L216.006 372Z" fill="#161616"/>
+</svg>
+    </SvgIcon>
+  );
+}

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,0 +1,1 @@
+export { EthuiIconWhite } from "./EthuiIconWhite";

--- a/src/components/items.tsx
+++ b/src/components/items.tsx
@@ -15,7 +15,7 @@ export default function Items() {
       </div>
       <hr />
       <div>
-        <h1>Mint NFT</h1>
+        <h1>Mint TEST</h1>
         <ERC20.Mint />
         <ERC20.Balance />
       </div>

--- a/src/components/nft/Mint.tsx
+++ b/src/components/nft/Mint.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "wagmi";
 
 export function Mint() {
   const { address } = useAccount();
-  const { writeContract, isIdle, ...args } = useWriteNftMint();
+  const { writeContract, isPending, ...args } = useWriteNftMint();
   console.log(args);
   console.log(address);
 
@@ -13,7 +13,7 @@ export function Mint() {
   return (
     <Button
       variant="contained"
-      disabled={!isIdle}
+      disabled={isPending}
       onClick={() => {
         console.log(address);
         writeContract({
@@ -22,7 +22,7 @@ export function Mint() {
         });
       }}
     >
-      {isIdle ? "Mint NFT" : "Minting..."}
+      {isPending ? "Minting..." : "Mint NFT"}
     </Button>
   );
 }

--- a/src/components/token/Mint.tsx
+++ b/src/components/token/Mint.tsx
@@ -4,14 +4,14 @@ import { useAccount } from "wagmi";
 
 export function Mint() {
   const { address } = useAccount();
-  const { writeContract, isIdle } = useWriteTokenMint();
+  const { isPending, writeContract } = useWriteTokenMint();
 
   if (!address) return null;
 
   return (
     <Button
       variant="contained"
-      disabled={!isIdle}
+      disabled={isPending}
       onClick={() => {
         writeContract({
           functionName: "mint", // https://github.com/wevm/wagmi/issues/3613
@@ -19,7 +19,7 @@ export function Mint() {
         });
       }}
     >
-      {isIdle ? "Mint $TEST" : "Minting..."}
+      {isPending ? "Minting..." : "Mint $TEST"}
     </Button>
   );
 }

--- a/src/components/token/Mint.tsx
+++ b/src/components/token/Mint.tsx
@@ -1,10 +1,10 @@
-import { useWriteNftMint } from "@/wagmi.generated";
+import { useWriteTokenMint } from "@/wagmi.generated";
 import { Button } from "@mui/material";
 import { useAccount } from "wagmi";
 
 export function Mint() {
   const { address } = useAccount();
-  const { writeContract, isIdle } = useWriteNftMint();
+  const { writeContract, isIdle } = useWriteTokenMint();
 
   if (!address) return null;
 
@@ -15,7 +15,7 @@ export function Mint() {
       onClick={() => {
         writeContract({
           functionName: "mint", // https://github.com/wevm/wagmi/issues/3613
-          args: [address],
+          args: [address, BigInt(1e18)],
         });
       }}
     >

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,7 +12,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <Theme>
       <QueryClientProvider client={queryClient}>
         <Head>
-          <title>Iron Demo</title>
+          <title>ehtui Demo</title>
           <meta name="description" content="A web3 demo app" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
         </Head>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,7 +12,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <Theme>
       <QueryClientProvider client={queryClient}>
         <Head>
-          <title>ehtui Demo</title>
+          <title>ethui Demo</title>
           <meta name="description" content="A web3 demo app" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
         </Head>


### PR DESCRIPTION
This PR updates the Mint TEST tokens button call and the Navbar.

**Why:**

- The Mint TEST tokens button was minting NFT's instead.
- Navbar had the old app name and generic icon

**How:**

- Updated the function call under the Mint Token component to `useWriteTokenMint()`
`src/components/token/Mint.tsx`
- Added a new Icon component and updated the Navbar title
`src/components/icons/EthuiIconWhite.tsx`
`src/components/Navbar.tsx`

**Preview:**

![image](https://github.com/ethui/web3-demo/assets/19204122/bdb30a3f-e046-4cbc-a7b9-fa17e6a0fc6e)


